### PR TITLE
chore(home): placeholders visuais conforme Figma e composição da página

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,5 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import Home from './pages/Home';
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+export default function App() {
+  return <Home />;
 }
-
-export default App

--- a/src/components/BrandRow/BrandRow.module.scss
+++ b/src/components/BrandRow/BrandRow.module.scss
@@ -1,0 +1,4 @@
+.section { padding:32px 0; }
+.title { text-align:center; font-size:22px; font-weight:800; margin:0 0 24px; }
+.row { display:grid; grid-template-columns:repeat(5,1fr); gap:24px; }
+.brand { aspect-ratio:1/1; border-radius:999px; background:#fff; box-shadow:0 8px 24px rgba(0,0,0,.08); }

--- a/src/components/BrandRow/BrandRow.tsx
+++ b/src/components/BrandRow/BrandRow.tsx
@@ -1,0 +1,14 @@
+import styles from './BrandRow.module.scss';
+
+export default function BrandRow() {
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <h2 className={styles.title}>Navegue por marcas</h2>
+        <div className={styles.row}>
+          {[1,2,3,4,5].map((n) => <div key={n} className={styles.brand} />)}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/BrandRow/index.ts
+++ b/src/components/BrandRow/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BrandRow';

--- a/src/components/CategoryNav/CategoryNav.module.scss
+++ b/src/components/CategoryNav/CategoryNav.module.scss
@@ -1,0 +1,5 @@
+.list { display:grid; grid-template-columns:repeat(7,1fr); gap:16px; }
+.item { display:flex; flex-direction:column; align-items:center; gap:8px;
+  padding:16px; border-radius:12px; background:#fff; box-shadow:0 4px 16px rgba(0,0,0,.06); }
+.icon { width:40px; height:40px; border-radius:8px; background:#e8e8ff; }
+.label { font-size:14px; }

--- a/src/components/CategoryNav/CategoryNav.tsx
+++ b/src/components/CategoryNav/CategoryNav.tsx
@@ -1,0 +1,20 @@
+import styles from './CategoryNav.module.scss';
+
+const items = ['Tecnologia','Supermercado','Bebidas','Ferramentas','Saúde','Esportes e Fitness','Moda'];
+
+export default function CategoryNav() {
+  return (
+    <section className="section">
+      <div className="container">
+        <ul className={styles.list} aria-label="Categorias rápidas">
+          {items.map((it) => (
+            <li key={it} className={styles.item}>
+              <div className={styles.icon} aria-hidden />
+              <span className={styles.label}>{it}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/components/CategoryNav/index.ts
+++ b/src/components/CategoryNav/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CategoryNav';

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -1,0 +1,1 @@
+.footer { background:#f7f7f7; padding:40px 0; }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,9 @@
+import styles from './Footer.module.scss';
+
+export default function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <div className="container" style={{ height: 220 }} />
+    </footer>
+  );
+}

--- a/src/components/Footer/index.ts
+++ b/src/components/Footer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Footer';

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -1,0 +1,3 @@
+.header { background:#fff; border-bottom:1px solid #eee; }
+.top { height:64px; display:flex; align-items:center; }
+.nav { height:40px; border-top:1px solid #eee; border-bottom:1px solid #eee; }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,12 @@
+import styles from './Header.module.scss';
+
+export default function Header() {
+  return (
+    <header className={styles.header}>
+      <div className="container">
+        <div className={styles.top} />
+        <nav className={styles.nav} aria-label="Categorias" />
+      </div>
+    </header>
+  );
+}

--- a/src/components/Header/index.ts
+++ b/src/components/Header/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Header';

--- a/src/components/HeroBanner/HeroBanner.module.scss
+++ b/src/components/HeroBanner/HeroBanner.module.scss
@@ -1,0 +1,2 @@
+.hero { padding:16px 0 24px; }
+.banner { height:320px; border-radius:16px; background:#111; }

--- a/src/components/HeroBanner/HeroBanner.tsx
+++ b/src/components/HeroBanner/HeroBanner.tsx
@@ -1,0 +1,11 @@
+import styles from './HeroBanner.module.scss';
+
+export default function HeroBanner() {
+  return (
+    <section className={styles.hero}>
+      <div className="container">
+        <div className={styles.banner} />
+      </div>
+    </section>
+  );
+}

--- a/src/components/HeroBanner/index.ts
+++ b/src/components/HeroBanner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HeroBanner';

--- a/src/components/Newsletter/Newsletter.module.scss
+++ b/src/components/Newsletter/Newsletter.module.scss
@@ -1,0 +1,5 @@
+.cta { background:#2c2256; padding:56px 0; }
+.title { color:#fff; text-align:center; font-size:24px; font-weight:800; margin:0; }
+.form { display:flex; gap:12px; justify-content:center; margin-top:12px; flex-wrap:wrap; }
+.input { padding:12px 14px; border-radius:8px; border:1px solid #ddd; min-width:220px; }
+.button { padding:12px 18px; border:0; border-radius:8px; background:#f6c31b; font-weight:700; }

--- a/src/components/Newsletter/Newsletter.tsx
+++ b/src/components/Newsletter/Newsletter.tsx
@@ -1,0 +1,16 @@
+import styles from './Newsletter.module.scss';
+
+export default function Newsletter() {
+  return (
+    <section className={styles.cta}>
+      <div className="container">
+        <h2 className={styles.title}>Inscreva-se na nossa newsletter</h2>
+        <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
+          <input className={styles.input} placeholder="Digite seu nome" aria-label="Seu nome" />
+          <input className={styles.input} placeholder="Digite seu e-mail" aria-label="Seu e-mail" />
+          <button className={styles.button} type="submit">INSCREVER</button>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Newsletter/index.ts
+++ b/src/components/Newsletter/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Newsletter';

--- a/src/components/PartnersSection/PartnersSection.module.scss
+++ b/src/components/PartnersSection/PartnersSection.module.scss
@@ -1,0 +1,6 @@
+.section { padding:32px 0; }
+.grid { display:grid; grid-template-columns:1fr 1fr; gap:24px; }
+.card { position:relative; border-radius:16px; overflow:hidden; background:#222; height:200px; }
+.title { position:absolute; left:16px; top:16px; color:#fff; font-weight:800; font-size:24px; }
+.subtitle { position:absolute; left:16px; top:48px; color:#fff; opacity:.9; }
+.cta { position:absolute; left:16px; bottom:16px; background:#f6c31b; border:0; border-radius:8px; padding:10px 16px; font-weight:700; }

--- a/src/components/PartnersSection/PartnersSection.tsx
+++ b/src/components/PartnersSection/PartnersSection.tsx
@@ -1,0 +1,19 @@
+import styles from './PartnersSection.module.scss';
+
+export default function PartnersSection() {
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <div className={styles.grid}>
+          {[1,2].map((n) => (
+            <div key={n} className={styles.card}>
+              <div className={styles.title}>Parceiros</div>
+              <div className={styles.subtitle}>Lorem ipsum dolor sit amet, consectetur.</div>
+              <button className={styles.cta} type="button">CONFIRA</button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/PartnersSection/index.ts
+++ b/src/components/PartnersSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PartnersSection';

--- a/src/components/RelatedProductsSection/RelatedProductsSection.module.scss
+++ b/src/components/RelatedProductsSection/RelatedProductsSection.module.scss
@@ -1,0 +1,22 @@
+.section { padding:32px 0; }
+.header { display:grid; place-items:center; position:relative; margin-bottom:8px; }
+.title { font-size:22px; font-weight:800; margin:0; }
+.link { position:absolute; right:0; top:0; background:none; border:0; color:#3d4ede; font-weight:600; }
+
+.tabs { display:flex; gap:8px; border-bottom:1px solid #eaeaea; margin:10px 0 20px; }
+.tab, .tabActive { background:transparent; border:0; padding:8px 12px; font-weight:700; font-size:14px; color:#808080; }
+.tabActive { color:#3d4ede; position:relative; }
+.tabActive::after { content:""; position:absolute; left:0; right:0; bottom:-1px; height:2px; background:#3d4ede; }
+
+.carousel { display:grid; grid-template-columns:32px 1fr 32px; align-items:center; gap:8px; }
+.arrow { width:32px; height:32px; border-radius:50%; border:1px solid #ddd; background:#fff; }
+
+.grid { display:grid; grid-template-columns:repeat(4,1fr); gap:20px; }
+.card { background:#fff; border-radius:12px; box-shadow:0 8px 24px rgba(0,0,0,.08); padding:16px; display:grid; gap:8px; }
+.thumb { height:160px; border-radius:8px; background:linear-gradient(#cfe6ff,#e9f1ff); }
+.cardTitle { font-size:14px; color:#555; font-weight:500; margin:0; }
+.oldPrice { color:#9a9a9a; text-decoration:line-through; margin:0; }
+.price { margin:-4px 0 0; font-size:14px; }
+.installments { color:#6b6b6b; font-size:12px; margin:0; }
+.free { color:#3d4ede; font-size:12px; margin:0; }
+.buy { margin-top:8px; height:40px; border:0; border-radius:8px; background:#3d4ede; color:#fff; font-weight:800; }

--- a/src/components/RelatedProductsSection/RelatedProductsSection.tsx
+++ b/src/components/RelatedProductsSection/RelatedProductsSection.tsx
@@ -1,0 +1,44 @@
+import styles from './RelatedProductsSection.module.scss';
+
+const tabs = ['CELULAR','ACESSÓRIOS','TABLETS','NOTEBOOKS','TVS','VER TODOS'];
+
+export default function RelatedProductsSection() {
+  return (
+    <section className={styles.section} aria-labelledby="related-title">
+      <div className="container">
+        <header className={styles.header}>
+          <h2 id="related-title" className={styles.title}>Produtos relacionados</h2>
+          <button className={styles.link} type="button">Ver todos</button>
+        </header>
+
+        <div className={styles.tabs} role="tablist" aria-label="Categorias">
+          {tabs.map((t, i) => (
+            <button key={t} role="tab" aria-selected={i === 0} className={i === 0 ? styles.tabActive : styles.tab}>
+              {t}
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.carousel}>
+          <button className={styles.arrow} aria-label="Anterior">‹</button>
+
+          <div className={styles.grid}>
+            {[1,2,3,4].map((n) => (
+              <article key={n} className={styles.card}>
+                <div className={styles.thumb} />
+                <h3 className={styles.cardTitle}>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</h3>
+                <p className={styles.oldPrice}>R$ 30,90</p>
+                <p className={styles.price}><strong>R$ 28,90</strong></p>
+                <p className={styles.installments}>ou 2x de R$ 14,95 sem juros</p>
+                <p className={styles.free}>Frete grátis</p>
+                <button className={styles.buy} type="button">COMPRAR</button>
+              </article>
+            ))}
+          </div>
+
+          <button className={styles.arrow} aria-label="Próximo">›</button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/RelatedProductsSection/index.ts
+++ b/src/components/RelatedProductsSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RelatedProductsSection';

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,26 @@
+import Header from '../components/Header';
+import HeroBanner from '../components/HeroBanner';
+import CategoryNav from '../components/CategoryNav';
+import RelatedProductsSection from '../components/RelatedProductsSection';
+import PartnersSection from '../components/PartnersSection';
+import BrandRow from '../components/BrandRow';
+import Newsletter from '../components/Newsletter';
+import Footer from '../components/Footer';
+
+export default function Home() {
+  return (
+    <>
+      <Header />
+      <HeroBanner />
+      <CategoryNav />
+      <RelatedProductsSection />
+      <PartnersSection />
+      <RelatedProductsSection />
+      <PartnersSection />
+      <BrandRow />
+      <RelatedProductsSection />
+      <Newsletter />
+      <Footer />
+    </>
+  );
+}

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,13 +1,10 @@
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; }
-body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color: #222; }
+body { margin: 0; background: #fafafa; color: #222;
+  font-family: system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif; }
 
-.visually-hidden {
-  position: absolute !important; width: 1px; height: 1px; overflow: hidden;
-  clip: rect(1px, 1px, 1px, 1px); white-space: nowrap;
-}
+.visually-hidden { position:absolute!important; width:1px; height:1px; overflow:hidden;
+  clip:rect(1px,1px,1px,1px); white-space:nowrap; }
 
 .container { max-width: 1200px; margin: 0 auto; padding: 0 16px; }
 .section { padding: 40px 0; }
-.sectionTitle { text-align: center; font-weight: 700; font-size: 24px; margin: 0 0 24px; }
-.subtle { color: #6b6b6b; font-size: 14px; text-align: center; margin-top: -12px; }


### PR DESCRIPTION
- Implementa placeholders para Header, HeroBanner, CategoryNav, RelatedProductsSection, PartnersSection, BrandRow, Newsletter e Footer
- Cria estilos mínimos (Sass) e utilitários globais (.container, .section)
- Sem lógica de dados (JSON) ou modal; apenas layout base